### PR TITLE
Removing subprojects directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+subprojects
+bin

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,9 +26,9 @@ project( leapr LANGUAGES CXX )
 get_directory_property( is_subproject PARENT_DIRECTORY )
 include( CMakeDependentOption REQUIRED )
 
-set( leapr_GNU_minimum_version 6.2 )
-set( leapr_Clang_minimum_version 3.8 )
 set( leapr_AppleClang_minimum_version 8.0 )
+set( leapr_Clang_minimum_version 3.8 )
+set( leapr_GNU_minimum_version 6.2 )
 
 if( leapr_${CMAKE_CXX_COMPILER_ID}_minimum_version )
     if( CMAKE_CXX_COMPILER_VERSION AND
@@ -69,79 +69,7 @@ if ( profile_generate )
     file( MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/profiling" )
 endif()
 
-set( leapr_GNU_Darwin_common_flags "-Wall" "-Wextra" "-Wpedantic" )
-set( leapr_GNU_Darwin_DEBUG_flags "-O0" "-g" "-gdwarf-3" "-fsignaling-nans" )
-set( leapr_GNU_Darwin_RELEASE_flags "-O3" "-DNDEBUG" )
-set( leapr_GNU_Darwin_strict_flags "-Werror" )
-set( leapr_GNU_Darwin_coverage_flags "--coverage" )
-set( leapr_GNU_Darwin_subproject_flags  )
-set( leapr_GNU_Darwin_base_project_flags  )
-set( leapr_GNU_Darwin_profile_generate_flags "-fprofile-generate='${CMAKE_BINARY_DIR}/profiling'" )
-set( leapr_GNU_Darwin_link_time_optimization_flags "-flto" )
-set( leapr_GNU_Darwin_profile_use_flags "-fprofile-use='${CMAKE_BINARY_DIR}/profiling'" )
-set( leapr_GNU_Darwin_nonportable_optimization_flags "-march=native" )
-set( leapr_GNU_Darwin_static_flags "-static" )
-set( leapr_GNU_Linux_common_flags "-Wall" "-Wextra" "-Wpedantic" )
-set( leapr_GNU_Linux_DEBUG_flags "-O0" "-g" "-gdwarf-3" "-fsignaling-nans" )
-set( leapr_GNU_Linux_RELEASE_flags "-O3" "-DNDEBUG" )
-set( leapr_GNU_Linux_strict_flags "-Werror" )
-set( leapr_GNU_Linux_coverage_flags "--coverage" )
-set( leapr_GNU_Linux_subproject_flags  )
-set( leapr_GNU_Linux_base_project_flags  )
-set( leapr_GNU_Linux_profile_generate_flags "-fprofile-generate='${CMAKE_BINARY_DIR}/profiling'" )
-set( leapr_GNU_Linux_link_time_optimization_flags "-flto" )
-set( leapr_GNU_Linux_profile_use_flags "-fprofile-use='${CMAKE_BINARY_DIR}/profiling'" )
-set( leapr_GNU_Linux_nonportable_optimization_flags "-march=native" )
-set( leapr_GNU_Linux_static_flags "-static" )
-set( leapr_GNU_Windows_common_flags "-Wall" "-Wextra" "-Wpedantic" )
-set( leapr_GNU_Windows_DEBUG_flags "-O0" "-g" "-gdwarf-3" "-fsignaling-nans" )
-set( leapr_GNU_Windows_RELEASE_flags "-O3" "-DNDEBUG" )
-set( leapr_GNU_Windows_strict_flags "-Werror" )
-set( leapr_GNU_Windows_coverage_flags "--coverage" )
-set( leapr_GNU_Windows_subproject_flags  )
-set( leapr_GNU_Windows_base_project_flags  )
-set( leapr_GNU_Windows_profile_generate_flags "-fprofile-generate='${CMAKE_BINARY_DIR}/profiling'" )
-set( leapr_GNU_Windows_link_time_optimization_flags "-flto" )
-set( leapr_GNU_Windows_profile_use_flags "-fprofile-use='${CMAKE_BINARY_DIR}/profiling'" )
-set( leapr_GNU_Windows_nonportable_optimization_flags "-march=native" )
-set( leapr_GNU_Windows_static_flags "-static" )
-set( leapr_Clang_Darwin_common_flags "-stdlib=libc++" "-Wall" "-Wextra" "-Wpedantic" )
-set( leapr_Clang_Darwin_DEBUG_flags "-O0" "-g" "-gdwarf-3" )
-set( leapr_Clang_Darwin_RELEASE_flags "-O3" "-DNDEBUG" )
-set( leapr_Clang_Darwin_strict_flags "-Werror" )
-set( leapr_Clang_Darwin_coverage_flags "--coverage" )
-set( leapr_Clang_Darwin_subproject_flags  )
-set( leapr_Clang_Darwin_base_project_flags  )
-set( leapr_Clang_Darwin_profile_generate_flags "-fprofile-generate='${CMAKE_BINARY_DIR}/profiling'" )
-set( leapr_Clang_Darwin_link_time_optimization_flags "-flto" )
-set( leapr_Clang_Darwin_profile_use_flags "-fprofile-use='${CMAKE_BINARY_DIR}/profiling'" )
-set( leapr_Clang_Darwin_nonportable_optimization_flags "-march=native" )
-set( leapr_Clang_Darwin_static_flags "-static" )
-set( leapr_Clang_Linux_common_flags "-stdlib=libstdc++" "-Wall" "-Wextra" "-Wpedantic" )
-set( leapr_Clang_Linux_DEBUG_flags "-O0" "-g" "-gdwarf-3" )
-set( leapr_Clang_Linux_RELEASE_flags "-O3" "-DNDEBUG" )
-set( leapr_Clang_Linux_strict_flags "-Werror" )
-set( leapr_Clang_Linux_coverage_flags "--coverage" )
-set( leapr_Clang_Linux_subproject_flags  )
-set( leapr_Clang_Linux_base_project_flags  )
-set( leapr_Clang_Linux_profile_generate_flags "-fprofile-generate='${CMAKE_BINARY_DIR}/profiling'" )
-set( leapr_Clang_Linux_link_time_optimization_flags "-flto" )
-set( leapr_Clang_Linux_profile_use_flags "-fprofile-use='${CMAKE_BINARY_DIR}/profiling'" )
-set( leapr_Clang_Linux_nonportable_optimization_flags "-march=native" )
-set( leapr_Clang_Linux_static_flags "-static" )
-set( leapr_Clang_Windows_common_flags "-stdlib=libc++" "-Wall" "-Wextra" "-Wpedantic" )
-set( leapr_Clang_Windows_DEBUG_flags "-O0" "-g" "-gdwarf-3" )
-set( leapr_Clang_Windows_RELEASE_flags "-O3" "-DNDEBUG" )
-set( leapr_Clang_Windows_strict_flags "-Werror" )
-set( leapr_Clang_Windows_coverage_flags "--coverage" )
-set( leapr_Clang_Windows_subproject_flags  )
-set( leapr_Clang_Windows_base_project_flags  )
-set( leapr_Clang_Windows_profile_generate_flags "-fprofile-generate='${CMAKE_BINARY_DIR}/profiling'" )
-set( leapr_Clang_Windows_link_time_optimization_flags "-flto" )
-set( leapr_Clang_Windows_profile_use_flags "-fprofile-use='${CMAKE_BINARY_DIR}/profiling'" )
-set( leapr_Clang_Windows_nonportable_optimization_flags "-march=native" )
-set( leapr_Clang_Windows_static_flags "-static" )
-set( leapr_AppleClang_Darwin_common_flags "-stdlib=libc++" "-Wall" "-Wextra" "-Wpedantic" )
+set( leapr_AppleClang_Darwin_common_flags "-stdlib=libc++" "-Wall" "-Wextra" "-Wpedantic" "-std=c++14" )
 set( leapr_AppleClang_Darwin_DEBUG_flags "-O0" "-g" "-gdwarf-3" )
 set( leapr_AppleClang_Darwin_RELEASE_flags "-O3" "-DNDEBUG" )
 set( leapr_AppleClang_Darwin_strict_flags "-Werror" )
@@ -153,6 +81,78 @@ set( leapr_AppleClang_Darwin_link_time_optimization_flags "-flto" )
 set( leapr_AppleClang_Darwin_profile_use_flags "-fprofile-use='${CMAKE_BINARY_DIR}/profiling'" )
 set( leapr_AppleClang_Darwin_nonportable_optimization_flags "-march=native" )
 set( leapr_AppleClang_Darwin_static_flags "-static" )
+set( leapr_Clang_Darwin_common_flags "-stdlib=libc++" "-Wall" "-Wextra" "-Wpedantic" "-std=c++14" )
+set( leapr_Clang_Darwin_DEBUG_flags "-O0" "-g" "-gdwarf-3" )
+set( leapr_Clang_Darwin_RELEASE_flags "-O3" "-DNDEBUG" )
+set( leapr_Clang_Darwin_strict_flags "-Werror" )
+set( leapr_Clang_Darwin_coverage_flags "--coverage" )
+set( leapr_Clang_Darwin_subproject_flags  )
+set( leapr_Clang_Darwin_base_project_flags  )
+set( leapr_Clang_Darwin_profile_generate_flags "-fprofile-generate='${CMAKE_BINARY_DIR}/profiling'" )
+set( leapr_Clang_Darwin_link_time_optimization_flags "-flto" )
+set( leapr_Clang_Darwin_profile_use_flags "-fprofile-use='${CMAKE_BINARY_DIR}/profiling'" )
+set( leapr_Clang_Darwin_nonportable_optimization_flags "-march=native" )
+set( leapr_Clang_Darwin_static_flags "-static" )
+set( leapr_Clang_Linux_common_flags "-stdlib=libstdc++" "-Wall" "-Wextra" "-Wpedantic" "-std=c++14" )
+set( leapr_Clang_Linux_DEBUG_flags "-O0" "-g" "-gdwarf-3" )
+set( leapr_Clang_Linux_RELEASE_flags "-O3" "-DNDEBUG" )
+set( leapr_Clang_Linux_strict_flags "-Werror" )
+set( leapr_Clang_Linux_coverage_flags "--coverage" )
+set( leapr_Clang_Linux_subproject_flags  )
+set( leapr_Clang_Linux_base_project_flags  )
+set( leapr_Clang_Linux_profile_generate_flags "-fprofile-generate='${CMAKE_BINARY_DIR}/profiling'" )
+set( leapr_Clang_Linux_link_time_optimization_flags "-flto" )
+set( leapr_Clang_Linux_profile_use_flags "-fprofile-use='${CMAKE_BINARY_DIR}/profiling'" )
+set( leapr_Clang_Linux_nonportable_optimization_flags "-march=native" )
+set( leapr_Clang_Linux_static_flags "-static" )
+set( leapr_Clang_Windows_common_flags "-stdlib=libc++" "-Wall" "-Wextra" "-Wpedantic" "-std=c++14" )
+set( leapr_Clang_Windows_DEBUG_flags "-O0" "-g" "-gdwarf-3" )
+set( leapr_Clang_Windows_RELEASE_flags "-O3" "-DNDEBUG" )
+set( leapr_Clang_Windows_strict_flags "-Werror" )
+set( leapr_Clang_Windows_coverage_flags "--coverage" )
+set( leapr_Clang_Windows_subproject_flags  )
+set( leapr_Clang_Windows_base_project_flags  )
+set( leapr_Clang_Windows_profile_generate_flags "-fprofile-generate='${CMAKE_BINARY_DIR}/profiling'" )
+set( leapr_Clang_Windows_link_time_optimization_flags "-flto" )
+set( leapr_Clang_Windows_profile_use_flags "-fprofile-use='${CMAKE_BINARY_DIR}/profiling'" )
+set( leapr_Clang_Windows_nonportable_optimization_flags "-march=native" )
+set( leapr_Clang_Windows_static_flags "-static" )
+set( leapr_GNU_Darwin_common_flags "-Wall" "-Wextra" "-Wpedantic" "-std=c++14" )
+set( leapr_GNU_Darwin_DEBUG_flags "-O0" "-g" "-gdwarf-3" "-fsignaling-nans" )
+set( leapr_GNU_Darwin_RELEASE_flags "-O3" "-DNDEBUG" )
+set( leapr_GNU_Darwin_strict_flags "-Werror" )
+set( leapr_GNU_Darwin_coverage_flags "--coverage" )
+set( leapr_GNU_Darwin_subproject_flags  )
+set( leapr_GNU_Darwin_base_project_flags  )
+set( leapr_GNU_Darwin_profile_generate_flags "-fprofile-generate='${CMAKE_BINARY_DIR}/profiling'" )
+set( leapr_GNU_Darwin_link_time_optimization_flags "-flto" )
+set( leapr_GNU_Darwin_profile_use_flags "-fprofile-use='${CMAKE_BINARY_DIR}/profiling'" )
+set( leapr_GNU_Darwin_nonportable_optimization_flags "-march=native" )
+set( leapr_GNU_Darwin_static_flags "-static" )
+set( leapr_GNU_Linux_common_flags "-Wall" "-Wextra" "-Wpedantic" "-std=c++14" )
+set( leapr_GNU_Linux_DEBUG_flags "-O0" "-g" "-gdwarf-3" "-fsignaling-nans" )
+set( leapr_GNU_Linux_RELEASE_flags "-O3" "-DNDEBUG" )
+set( leapr_GNU_Linux_strict_flags "-Werror" )
+set( leapr_GNU_Linux_coverage_flags "--coverage" )
+set( leapr_GNU_Linux_subproject_flags  )
+set( leapr_GNU_Linux_base_project_flags  )
+set( leapr_GNU_Linux_profile_generate_flags "-fprofile-generate='${CMAKE_BINARY_DIR}/profiling'" )
+set( leapr_GNU_Linux_link_time_optimization_flags "-flto" )
+set( leapr_GNU_Linux_profile_use_flags "-fprofile-use='${CMAKE_BINARY_DIR}/profiling'" )
+set( leapr_GNU_Linux_nonportable_optimization_flags "-march=native" )
+set( leapr_GNU_Linux_static_flags "-static" )
+set( leapr_GNU_Windows_common_flags "-Wall" "-Wextra" "-Wpedantic" "-std=c++14" )
+set( leapr_GNU_Windows_DEBUG_flags "-O0" "-g" "-gdwarf-3" "-fsignaling-nans" )
+set( leapr_GNU_Windows_RELEASE_flags "-O3" "-DNDEBUG" )
+set( leapr_GNU_Windows_strict_flags "-Werror" )
+set( leapr_GNU_Windows_coverage_flags "--coverage" )
+set( leapr_GNU_Windows_subproject_flags  )
+set( leapr_GNU_Windows_base_project_flags  )
+set( leapr_GNU_Windows_profile_generate_flags "-fprofile-generate='${CMAKE_BINARY_DIR}/profiling'" )
+set( leapr_GNU_Windows_link_time_optimization_flags "-flto" )
+set( leapr_GNU_Windows_profile_use_flags "-fprofile-use='${CMAKE_BINARY_DIR}/profiling'" )
+set( leapr_GNU_Windows_nonportable_optimization_flags "-march=native" )
+set( leapr_GNU_Windows_static_flags "-static" )
 
 if ( static_leapr )
     set( leapr_library_linkage STATIC )
@@ -171,12 +171,12 @@ list( INSERT 0 CMAKE_INSTALL_RPATH "${rpath_prefix}/../lib" )
 set( CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE )
 get_directory_property( is_subproject PARENT_DIRECTORY )
 
-if( NOT TARGET eigen-adapter )
-    add_subdirectory( ${ROOT_DIRECTORY}/subprojects/eigen-adapter )
-endif()
-
 if( NOT TARGET catch-adapter )
     add_subdirectory( ${ROOT_DIRECTORY}/subprojects/catch-adapter )
+endif()
+
+if( NOT TARGET eigen-adapter )
+    add_subdirectory( ${ROOT_DIRECTORY}/subprojects/eigen-adapter )
 endif()
 
 
@@ -210,25 +210,18 @@ message( STATUS "" )
 message( STATUS "-----------------------------------------------------------" )
 
 add_library( leapr ${leapr_library_linkage} 
-             "${CMAKE_CURRENT_SOURCE_DIR}/src/trans/trans.h"
-             "${CMAKE_CURRENT_SOURCE_DIR}/src/trans/trans_util/terps.h"
-             "${CMAKE_CURRENT_SOURCE_DIR}/src/trans/trans_util/s_table_generation.h"
-             "${CMAKE_CURRENT_SOURCE_DIR}/src/trans/trans_util/bessel_K1.h"
-             "${CMAKE_CURRENT_SOURCE_DIR}/src/trans/trans_util/sbfill.h"
              "${CMAKE_CURRENT_SOURCE_DIR}/src/coher/coher.h"
              "${CMAKE_CURRENT_SOURCE_DIR}/src/coher/coher_util/bccLatticeFactors.h"
+             "${CMAKE_CURRENT_SOURCE_DIR}/src/coher/coher_util/end.h"
+             "${CMAKE_CURRENT_SOURCE_DIR}/src/coher/coher_util/fccLatticeFactors.h"
              "${CMAKE_CURRENT_SOURCE_DIR}/src/coher/coher_util/formf.h"
              "${CMAKE_CURRENT_SOURCE_DIR}/src/coher/coher_util/hexLatticeFactors.h"
-             "${CMAKE_CURRENT_SOURCE_DIR}/src/coher/coher_util/fccLatticeFactors.h"
-             "${CMAKE_CURRENT_SOURCE_DIR}/src/coher/coher_util/end.h"
              "${CMAKE_CURRENT_SOURCE_DIR}/src/coher/coher_util/hexLatticeFactors_util/hexLatticeFactorsHelper.h"
-             "${CMAKE_CURRENT_SOURCE_DIR}/src/skold/skold.h"
-             "${CMAKE_CURRENT_SOURCE_DIR}/src/skold/skold_util/terp1.h"
              "${CMAKE_CURRENT_SOURCE_DIR}/src/coldh/coldh.h"
              "${CMAKE_CURRENT_SOURCE_DIR}/src/coldh/coldh_util/betaLoop.h"
              "${CMAKE_CURRENT_SOURCE_DIR}/src/coldh/coldh_util/terpk.h"
-             "${CMAKE_CURRENT_SOURCE_DIR}/src/coldh/coldh_util/betaLoop_util/jprimeLoop.h"
              "${CMAKE_CURRENT_SOURCE_DIR}/src/coldh/coldh_util/betaLoop_util/bt.h"
+             "${CMAKE_CURRENT_SOURCE_DIR}/src/coldh/coldh_util/betaLoop_util/jprimeLoop.h"
              "${CMAKE_CURRENT_SOURCE_DIR}/src/coldh/coldh_util/betaLoop_util/jprimeLoop_util/sumh.h"
              "${CMAKE_CURRENT_SOURCE_DIR}/src/coldh/coldh_util/betaLoop_util/jprimeLoop_util/sumh_util/cn.h"
              "${CMAKE_CURRENT_SOURCE_DIR}/src/coldh/coldh_util/betaLoop_util/jprimeLoop_util/sumh_util/sjbes.h"
@@ -238,13 +231,20 @@ add_library( leapr ${leapr_library_linkage}
              "${CMAKE_CURRENT_SOURCE_DIR}/src/contin/contin_util/start.h"
              "${CMAKE_CURRENT_SOURCE_DIR}/src/contin/contin_util/start_util/start_util.h"
              "${CMAKE_CURRENT_SOURCE_DIR}/src/discre/discre.h"
-             "${CMAKE_CURRENT_SOURCE_DIR}/src/discre/discre_util/oscLoopFuncs.h"
-             "${CMAKE_CURRENT_SOURCE_DIR}/src/discre/discre_util/sint.h"
+             "${CMAKE_CURRENT_SOURCE_DIR}/src/discre/discre_util/addDeltaFuncs.h"
              "${CMAKE_CURRENT_SOURCE_DIR}/src/discre/discre_util/bfill.h"
              "${CMAKE_CURRENT_SOURCE_DIR}/src/discre/discre_util/exts.h"
+             "${CMAKE_CURRENT_SOURCE_DIR}/src/discre/discre_util/oscLoopFuncs.h"
              "${CMAKE_CURRENT_SOURCE_DIR}/src/discre/discre_util/prepareParams.h"
-             "${CMAKE_CURRENT_SOURCE_DIR}/src/discre/discre_util/addDeltaFuncs.h"
+             "${CMAKE_CURRENT_SOURCE_DIR}/src/discre/discre_util/sint.h"
              "${CMAKE_CURRENT_SOURCE_DIR}/src/discre/discre_util/oscLoopFuncs_util/bfact.h"
+             "${CMAKE_CURRENT_SOURCE_DIR}/src/skold/skold.h"
+             "${CMAKE_CURRENT_SOURCE_DIR}/src/skold/skold_util/terp1.h"
+             "${CMAKE_CURRENT_SOURCE_DIR}/src/trans/trans.h"
+             "${CMAKE_CURRENT_SOURCE_DIR}/src/trans/trans_util/bessel_K1.h"
+             "${CMAKE_CURRENT_SOURCE_DIR}/src/trans/trans_util/s_table_generation.h"
+             "${CMAKE_CURRENT_SOURCE_DIR}/src/trans/trans_util/sbfill.h"
+             "${CMAKE_CURRENT_SOURCE_DIR}/src/trans/trans_util/terps.h"
              "${CMAKE_CURRENT_SOURCE_DIR}/src/leapr.cpp" )
 
 target_include_directories( leapr PUBLIC src )
@@ -270,66 +270,31 @@ ${CXX_appended_flags} ${leapr_appended_flags} )
 
 target_link_libraries( leapr PUBLIC "$<$<AND:$<CONFIG:RELEASE>,$<BOOL:${link_time_optimization}>>:${${PREFIX}_RELEASE_flags};${${PREFIX}_link_time_optimization_flags}$<$<BOOL:${profile_generate}>:${${PREFIX}_profile_generate_flags};>$<$<BOOL:${profile_use}>:${${PREFIX}_profile_use_flags};>$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags};>>$<$<CONFIG:DEBUG>:$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags};>>$<$<BOOL:CXX_appended_flags>:${CXX_appended_flags};>$<$<BOOL:leapr_appended_flags>:${leapr_appended_flags};>" )
 
-target_link_libraries( leapr PUBLIC eigen-adapter PUBLIC catch-adapter )
-
-if ( NOT is_subproject )
-    add_executable( leapr_executable src/leapr.cpp )
-    set_target_properties( leapr_executable PROPERTIES OUTPUT_NAME leapr )
-    target_compile_options( leapr_executable PRIVATE 
-    ${${PREFIX}_common_flags}
-    $<$<BOOL:${leapr_strict}>:${${PREFIX}_strict_flags}>
-    $<$<BOOL:${static}>:${${PREFIX}_static_flags}>
-    $<$<BOOL:${is_subproject}>:${${PREFIX}_subproject_flags}>
-    $<$<NOT:$<BOOL:${is_subproject}>>:${${PREFIX}_base_project_flags}>
-    $<$<CONFIG:DEBUG>:
-    ${${PREFIX}_DEBUG_flags} 
-    $<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
-    $<$<CONFIG:RELEASE>:
-    ${${PREFIX}_RELEASE_flags} 
-    $<$<BOOL:${profile_generate}>:${${PREFIX}_profile_generate_flags}> 
-    $<$<BOOL:${profile_use}>:${${PREFIX}_profile_use_flags}> 
-    $<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}> 
-    $<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
-    ${CXX_appended_flags} ${leapr_appended_flags} )
-    target_link_libraries( leapr_executable PUBLIC leapr )
-endif()
+target_link_libraries( leapr PUBLIC catch-adapter PUBLIC eigen-adapter )
 
 if( NOT is_subproject )
     enable_testing() 
     if ( unit_tests )
-        add_subdirectory( src/skold/skold_util/test )
-        add_subdirectory( src/coher/test )
-        add_subdirectory( src/discre/discre_util/test )
-        add_subdirectory( src/discre/discre_util/oscLoopFuncs_util/test )
-        add_subdirectory( src/coher/coher_util/hexLatticeFactors_util/test )
         add_subdirectory( src/contin/test )
-        add_subdirectory( src/discre/test )
-        add_subdirectory( src/coldh/coldh_util/betaLoop_util/jprimeLoop_util/sumh_util/test )
-        add_subdirectory( src/trans/test )
-        add_subdirectory( src/coldh/coldh_util/betaLoop_util/jprimeLoop_util/test )
+        add_subdirectory( src/discre/discre_util/oscLoopFuncs_util/test )
         add_subdirectory( src/contin/contin_util/test )
+        add_subdirectory( src/coher/coher_util/hexLatticeFactors_util/test )
         add_subdirectory( src/trans/trans_util/test )
         add_subdirectory( src/coher/coher_util/test )
+        add_subdirectory( src/trans/test )
+        add_subdirectory( src/skold/test )
+        add_subdirectory( src/discre/discre_util/test )
+        add_subdirectory( src/skold/skold_util/test )
+        add_subdirectory( src/contin/contin_util/start_util/test )
+        add_subdirectory( src/coldh/coldh_util/betaLoop_util/jprimeLoop_util/sumh_util/test )
         add_subdirectory( src/coldh/coldh_util/test )
         add_subdirectory( src/coldh/test )
-        add_subdirectory( src/skold/test )
-        add_subdirectory( src/contin/contin_util/start_util/test )
         add_subdirectory( src/coldh/coldh_util/betaLoop_util/test )
+        add_subdirectory( src/coher/test )
+        add_subdirectory( src/coldh/coldh_util/betaLoop_util/jprimeLoop_util/test )
+        add_subdirectory( src/discre/test )
     endif() 
 endif()
-
-set( installation_targets leapr )
-if ( NOT is_subproject )
-    list( APPEND installation_targets leapr_executable )
-endif()
-
-install( TARGETS ${installation_targets} 
-         RUNTIME DESTINATION bin
-         LIBRARY DESTINATION lib
-         ARCHIVE DESTINATION lib
-         PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ 
-                     GROUP_EXECUTE GROUP_READ 
-                     WORLD_EXECUTE WORLD_READ )
 
 install( DIRECTORY src/ DESTINATION include
          FILE_PERMISSIONS OWNER_READ OWNER_WRITE 

--- a/metaconfigure/description.json
+++ b/metaconfigure/description.json
@@ -350,7 +350,6 @@
       }
     }
   },
-  "driver": "src/leapr.cpp",
   "file extension": {
     "header files": [
       "h++",
@@ -368,25 +367,18 @@
     ]
   },
   "header files": [
-    "src/trans/trans.h",
-    "src/trans/trans_util/terps.h",
-    "src/trans/trans_util/s_table_generation.h",
-    "src/trans/trans_util/bessel_K1.h",
-    "src/trans/trans_util/sbfill.h",
     "src/coher/coher.h",
     "src/coher/coher_util/bccLatticeFactors.h",
+    "src/coher/coher_util/end.h",
+    "src/coher/coher_util/fccLatticeFactors.h",
     "src/coher/coher_util/formf.h",
     "src/coher/coher_util/hexLatticeFactors.h",
-    "src/coher/coher_util/fccLatticeFactors.h",
-    "src/coher/coher_util/end.h",
     "src/coher/coher_util/hexLatticeFactors_util/hexLatticeFactorsHelper.h",
-    "src/skold/skold.h",
-    "src/skold/skold_util/terp1.h",
     "src/coldh/coldh.h",
     "src/coldh/coldh_util/betaLoop.h",
     "src/coldh/coldh_util/terpk.h",
-    "src/coldh/coldh_util/betaLoop_util/jprimeLoop.h",
     "src/coldh/coldh_util/betaLoop_util/bt.h",
+    "src/coldh/coldh_util/betaLoop_util/jprimeLoop.h",
     "src/coldh/coldh_util/betaLoop_util/jprimeLoop_util/sumh.h",
     "src/coldh/coldh_util/betaLoop_util/jprimeLoop_util/sumh_util/cn.h",
     "src/coldh/coldh_util/betaLoop_util/jprimeLoop_util/sumh_util/sjbes.h",
@@ -396,13 +388,20 @@
     "src/contin/contin_util/start.h",
     "src/contin/contin_util/start_util/start_util.h",
     "src/discre/discre.h",
-    "src/discre/discre_util/oscLoopFuncs.h",
-    "src/discre/discre_util/sint.h",
+    "src/discre/discre_util/addDeltaFuncs.h",
     "src/discre/discre_util/bfill.h",
     "src/discre/discre_util/exts.h",
+    "src/discre/discre_util/oscLoopFuncs.h",
     "src/discre/discre_util/prepareParams.h",
-    "src/discre/discre_util/addDeltaFuncs.h",
-    "src/discre/discre_util/oscLoopFuncs_util/bfact.h"
+    "src/discre/discre_util/sint.h",
+    "src/discre/discre_util/oscLoopFuncs_util/bfact.h",
+    "src/skold/skold.h",
+    "src/skold/skold_util/terp1.h",
+    "src/trans/trans.h",
+    "src/trans/trans_util/bessel_K1.h",
+    "src/trans/trans_util/s_table_generation.h",
+    "src/trans/trans_util/sbfill.h",
+    "src/trans/trans_util/terps.h"
   ],
   "ignore pattern": "$^",
   "implementation files": [
@@ -413,6 +412,7 @@
   "is external project": false,
   "language": "c++",
   "name": "leapr",
+  "standard": "c++14",
   "standards": [
     "c++98",
     "c++11",
@@ -425,11 +425,11 @@
       "src/coher/test/coher.test.cpp"
     ],
     "coher.coher_util": [
-      "src/coher/coher_util/test/end.test.cpp",
       "src/coher/coher_util/test/bccLatticeFactors.test.cpp",
-      "src/coher/coher_util/test/hexLatticeFactors.test.cpp",
+      "src/coher/coher_util/test/end.test.cpp",
       "src/coher/coher_util/test/fccLatticeFactors.test.cpp",
-      "src/coher/coher_util/test/formf.test.cpp"
+      "src/coher/coher_util/test/formf.test.cpp",
+      "src/coher/coher_util/test/hexLatticeFactors.test.cpp"
     ],
     "coher.coher_util.hexLatticeFactors_util": [
       "src/coher/coher_util/hexLatticeFactors_util/test/hexLatticeFactorsHelper.test.cpp"
@@ -438,8 +438,8 @@
       "src/coldh/test/coldh.test.cpp"
     ],
     "coldh.coldh_util": [
-      "src/coldh/coldh_util/test/terpk.test.cpp",
-      "src/coldh/coldh_util/test/betaLoop.test.cpp"
+      "src/coldh/coldh_util/test/betaLoop.test.cpp",
+      "src/coldh/coldh_util/test/terpk.test.cpp"
     ],
     "coldh.coldh_util.betaLoop_util": [
       "src/coldh/coldh_util/betaLoop_util/test/bt.test.cpp",
@@ -457,8 +457,8 @@
     ],
     "contin.contin_util": [
       "src/contin/contin_util/test/convol.test.cpp",
-      "src/contin/contin_util/test/start.test.cpp",
-      "src/contin/contin_util/test/interpolate.test.cpp"
+      "src/contin/contin_util/test/interpolate.test.cpp",
+      "src/contin/contin_util/test/start.test.cpp"
     ],
     "contin.contin_util.start_util": [
       "src/contin/contin_util/start_util/test/start_util.test.cpp"
@@ -467,12 +467,12 @@
       "src/discre/test/discre.test.cpp"
     ],
     "discre.discre_util": [
-      "src/discre/discre_util/test/prepareParams.test.cpp",
-      "src/discre/discre_util/test/exts.test.cpp",
-      "src/discre/discre_util/test/sint.test.cpp",
-      "src/discre/discre_util/test/bfill.test.cpp",
       "src/discre/discre_util/test/addDeltaFuncs.test.cpp",
-      "src/discre/discre_util/test/oscLoopFuncs.test.cpp"
+      "src/discre/discre_util/test/bfill.test.cpp",
+      "src/discre/discre_util/test/exts.test.cpp",
+      "src/discre/discre_util/test/oscLoopFuncs.test.cpp",
+      "src/discre/discre_util/test/prepareParams.test.cpp",
+      "src/discre/discre_util/test/sint.test.cpp"
     ],
     "discre.discre_util.oscLoopFuncs_util": [
       "src/discre/discre_util/oscLoopFuncs_util/test/bfact.test.cpp"
@@ -487,8 +487,8 @@
       "src/trans/test/trans.test.cpp"
     ],
     "trans.trans_util": [
-      "src/trans/trans_util/test/s_table_generation.test.cpp",
       "src/trans/trans_util/test/bessel_K1.test.cpp",
+      "src/trans/trans_util/test/s_table_generation.test.cpp",
       "src/trans/trans_util/test/sbfill.test.cpp",
       "src/trans/trans_util/test/terps.test.cpp"
     ]

--- a/src/coher/coher_util/test/CMakeLists.txt
+++ b/src/coher/coher_util/test/CMakeLists.txt
@@ -1,10 +1,10 @@
 
 add_executable( coher.coher_util.test
-                end.test.cpp
                 bccLatticeFactors.test.cpp
-                hexLatticeFactors.test.cpp
+                end.test.cpp
                 fccLatticeFactors.test.cpp
-                formf.test.cpp )
+                formf.test.cpp
+                hexLatticeFactors.test.cpp )
 target_compile_options( coher.coher_util.test PRIVATE ${${PREFIX}_common_flags}
 $<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
 ${${PREFIX}_DEBUG_flags}

--- a/src/coldh/coldh_util/test/CMakeLists.txt
+++ b/src/coldh/coldh_util/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 add_executable( coldh.coldh_util.test
-                terpk.test.cpp
-                betaLoop.test.cpp )
+                betaLoop.test.cpp
+                terpk.test.cpp )
 target_compile_options( coldh.coldh_util.test PRIVATE ${${PREFIX}_common_flags}
 $<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
 ${${PREFIX}_DEBUG_flags}

--- a/src/contin/contin_util/test/CMakeLists.txt
+++ b/src/contin/contin_util/test/CMakeLists.txt
@@ -1,8 +1,8 @@
 
 add_executable( contin.contin_util.test
                 convol.test.cpp
-                start.test.cpp
-                interpolate.test.cpp )
+                interpolate.test.cpp
+                start.test.cpp )
 target_compile_options( contin.contin_util.test PRIVATE ${${PREFIX}_common_flags}
 $<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
 ${${PREFIX}_DEBUG_flags}

--- a/src/discre/discre_util/test/CMakeLists.txt
+++ b/src/discre/discre_util/test/CMakeLists.txt
@@ -1,11 +1,11 @@
 
 add_executable( discre.discre_util.test
-                prepareParams.test.cpp
-                exts.test.cpp
-                sint.test.cpp
-                bfill.test.cpp
                 addDeltaFuncs.test.cpp
-                oscLoopFuncs.test.cpp )
+                bfill.test.cpp
+                exts.test.cpp
+                oscLoopFuncs.test.cpp
+                prepareParams.test.cpp
+                sint.test.cpp )
 target_compile_options( discre.discre_util.test PRIVATE ${${PREFIX}_common_flags}
 $<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
 ${${PREFIX}_DEBUG_flags}

--- a/src/trans/trans_util/test/CMakeLists.txt
+++ b/src/trans/trans_util/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 add_executable( trans.trans_util.test
-                s_table_generation.test.cpp
                 bessel_K1.test.cpp
+                s_table_generation.test.cpp
                 sbfill.test.cpp
                 terps.test.cpp )
 target_compile_options( trans.trans_util.test PRIVATE ${${PREFIX}_common_flags}

--- a/subprojects/catch-adapter
+++ b/subprojects/catch-adapter
@@ -1,1 +1,0 @@
-/home/ameliajo/leapr/dependencies/catch-adapter

--- a/subprojects/eigen-adapter
+++ b/subprojects/eigen-adapter
@@ -1,1 +1,0 @@
-/home/ameliajo/leapr/dependencies/eigen-adapter


### PR DESCRIPTION
One problem with your build is that you had links in your `subprojects` directory. You don't need to put those there because `metaconfigure` will do that for you. I was still not able to get everything built because of a missing Qt error. Hopefully you won't encounter the same thing.