### PR TITLE
Changing g++-9 to g++-8.

### DIFF
--- a/.github/workflows/ContinuousIntegration.yml
+++ b/.github/workflows/ContinuousIntegration.yml
@@ -14,8 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-18.04, macos-10.15 ]
-        #cxx: [ g++-9, clang++ ]
-        cxx: [ clang++ ]
+        cxx: [ g++-8, clang++ ]
         build_type: [ Debug, Release ]
 
     steps:


### PR DESCRIPTION
In trying to figure out why NJOY21 wouldn't compile in GitHub Actions, I discovered what I think is a bug in the installation of GCC-9.. (See [here](https://github.com/actions/virtual-environments/issues/2215) for more information.) This Pull Request uses GCC-8 instead.